### PR TITLE
Fix BENCHMARK_OS var and audit_content_version

### DIFF
--- a/run_audit.sh
+++ b/run_audit.sh
@@ -24,7 +24,7 @@
 # Goss benchmark variables (these should not need changing unless new release)
 BENCHMARK=CIS # Benchmark Name aligns to the audit
 BENCHMARK_VER=1.0.0
-BENCHMARK_OS=Amazon2023
+BENCHMARK_OS=AMAZON2023
 
 # Goss host Variables
 AUDIT_BIN="${AUDIT_BIN:-/usr/local/bin/goss}"  # location of the goss executable
@@ -91,7 +91,7 @@ else
 fi
 
 os_maj_ver="$(grep -w VERSION_ID= /etc/os-release | awk -F\" '{print $2}' | cut -d '.' -f1)"
-audit_content_version=$os_vendor$os_maj_ver-$BENCHMARK-Audit
+audit_content_version=$BENCHMARK_OS-$BENCHMARK-Audit
 audit_content_dir=$AUDIT_CONTENT_LOCATION/$audit_content_version
 audit_vars=vars/${BENCHMARK}.yml
 


### PR DESCRIPTION
**Overall Review of Changes:**
BENCHMARK_OS needs to be capitalized (on unix systems/case sensitive file systems)  audit_content_version should use the correct vars to build the string that matches the audit repo name.

**Issue Fixes:**
The audit doesn't run as is when I pull down the repo. I've been running 'sed' commands in my pipeline to fix these issues. I didn't create a ticket but I can if needed.

**Enhancements:**
n/A

**How has this been tested?:**
Running in my pipeline:

      "git clone https://github.com/ansible-lockdown/AMAZON2023-CIS-Audit.git",
      "wget -q https://github.com/goss-org/goss/releases/download/v0.4.9/goss-linux-amd64",
      "sudo mv goss-linux-amd64 /usr/local/bin/goss",
      "sudo chmod 755 /usr/local/bin/goss",
      "sed -i 's/audit_content_version=$os_vendor$os_maj_ver-$BENCHMARK-Audit/audit_content_version=$BENCHMARK_OS-$BENCHMARK-Audit/' AMAZON2023-CIS-Audit/run_audit.sh",
      "sed -i 's/BENCHMARK_OS=Amazon2023/BENCHMARK_OS=AMAZON2023/' AMAZON2023-CIS-Audit/run_audit.sh",
      "sudo AUDIT_CONTENT_LOCATION=/audit bash AMAZON2023-CIS-Audit/run_audit.sh",

