### PR TITLE
add missing audispd and add selinux to all attributes

### DIFF
--- a/section_1/cis_1.3/cis_1.3.3.yml
+++ b/section_1/cis_1.3/cis_1.3.3.yml
@@ -10,12 +10,13 @@ command:
         - 0
         - 2
     stdout:
-      - '/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512'
-      - '/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512'
-      - '/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512'
-      - '/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512'
-      - '/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512'
-      - '/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512'
+      - '/sbin/auditctl p+i+n+u+g+s+b+acl+selinux+xattrs+sha512'
+      - '/sbin/auditd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512'
+      - '/sbin/ausearch p+i+n+u+g+s+b+acl+selinux+xattrs+sha512'
+      - '/sbin/aureport p+i+n+u+g+s+b+acl+selinux+xattrs+sha512'
+      - '/sbin/autrace p+i+n+u+g+s+b+acl+selinux+xattrs+sha512'
+      - '/sbin/augenrules p+i+n+u+g+s+b+acl+selinux+xattrs+sha512'
+      - '/sbin/audispd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512'
     meta:
       server: 1
       workstation: 1


### PR DESCRIPTION
**Overall Review of Changes:**
Similar to https://github.com/ansible-lockdown/AMAZON2023-CIS/pull/137 the audit needs to reflect the missing audispd command and selinux attributes

**Issue Fixes:**
I didn't create an issue but I can if necessary

**Enhancements:**
N/A

**How has this been tested?:**
I haven't tested this directly but I have changed the SSG to match these and that passes.

